### PR TITLE
add auth refresh flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/client-s3": "^3.876.0",
     "@aws-sdk/s3-request-presigner": "^3.876.0",
     "@eslint/js": "^9.34.0",
-    "@seanboose/personal-website-api-types": "^1.0.7",
+    "@seanboose/personal-website-api-types": "1.0.11",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/jsonwebtoken": "^9.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^9.34.0
         version: 9.38.0
       '@seanboose/personal-website-api-types':
-        specifier: ^1.0.7
-        version: 1.0.7
+        specifier: 1.0.11
+        version: 1.0.11
       '@types/cors':
         specifier: ^2.8.19
         version: 2.8.19
@@ -467,8 +467,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@seanboose/personal-website-api-types@1.0.7':
-    resolution: {integrity: sha512-2MdzDgJxBPgTgKf5OwfdPPCQPvd8lVBBwJU+SS1XQ0kwWjbrliiXLLrsOM+z5lhyG2L7xuDi4LX5+SAniOkjaw==, tarball: https://npm.pkg.github.com/download/@seanboose/personal-website-api-types/1.0.7/937640c790b277792798f0777fa71313771ba095}
+  '@seanboose/personal-website-api-types@1.0.11':
+    resolution: {integrity: sha512-tjd6MBB79I4iM10P2uP/dzu0Jw4Pfds7qNBqmjjiXa99goOs9dvcJu8rBRUrf5IBW0WoUazLjcKiIfLtd+4TVw==, tarball: https://npm.pkg.github.com/download/@seanboose/personal-website-api-types/1.0.11/6016af5154961cd8f8119a1e908f4f09812ae479}
 
   '@smithy/abort-controller@4.2.3':
     resolution: {integrity: sha512-xWL9Mf8b7tIFuAlpjKtRPnHrR8XVrwTj5NPYO/QwZPtc0SDLsPxb56V5tzi5yspSMytISHybifez+4jlrx0vkQ==}
@@ -2299,7 +2299,7 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@seanboose/personal-website-api-types@1.0.7': {}
+  '@seanboose/personal-website-api-types@1.0.11': {}
 
   '@smithy/abort-controller@4.2.3':
     dependencies:

--- a/src/features/auth/auth.controllers.ts
+++ b/src/features/auth/auth.controllers.ts
@@ -1,4 +1,4 @@
-import type { RequestHandler } from 'express';
+import type { RequestHandler, Response } from 'express';
 import jwt from 'jsonwebtoken';
 
 import { config } from '../../shared/config.js';
@@ -7,12 +7,15 @@ import {
   accessAgeS,
   generateAccessToken,
   generateRefreshToken,
-  type JwtPayload,
+  type JwtRequestPayload,
   refreshAgeS,
 } from './auth.service.js';
 
 const authRequestHeader = 'internal-auth-key';
 const authRequestClientKey = 'auth-request-client';
+// TODO can these live in api-types
+const accessTokenName = 'access_token';
+const refreshTokenName = 'refresh_token';
 
 export const grantAuth: RequestHandler = (req, res) => {
   const authRequestKey = req.headers[authRequestHeader];
@@ -25,48 +28,31 @@ export const grantAuth: RequestHandler = (req, res) => {
     return res.status(400).json({ message: 'Bad Request, no client provided' });
   }
 
-  const payload: JwtPayload = { authRequestClientKey: client };
-  // TODO this was allowing me to pass a string. wtf
-  const accessToken = generateAccessToken(payload);
-  res.cookie('access_token', accessToken, {
-    httpOnly: true,
-    secure: true,
-    sameSite: 'none',
-    maxAge: accessAgeS * 1000,
-  });
-
-  const refreshToken = generateRefreshToken(payload);
-  res.cookie('refresh_token', refreshToken, {
-    httpOnly: true,
-    secure: true,
-    sameSite: 'none',
-    maxAge: refreshAgeS * 1000,
-  });
-  res.status(200).json({ message: 'Auth granted' });
+  createAndSetAuthCookies(res, client);
 };
 
 export const refreshAuth: RequestHandler = (req, res) => {
-  let client;
-  console.log(req);
   const refreshToken = readRefreshToken(req);
-  console.log(refreshToken);
-  jwt.verify(refreshToken, config.jwtKey, (err: unknown, decoded: unknown) => {
+  let decoded;
+  try {
+    decoded = jwt.verify(refreshToken, config.jwtKey);
+  } catch (err) {
     if (err instanceof Error && err.name === 'TokenExpiredError') {
-      console.log('REFRESH_TOKEN_EXPIRED');
       return res
         .status(401)
         .json({ error: 'REFRESH_TOKEN_EXPIRED', message: 'Session expired' });
     } else if (err) {
-      console.log('REFRESH_TOKEN_INVALID');
       return res.status(401).json({
         error: 'REFRESH_TOKEN_INVALID',
         message: 'Invalid refresh token',
       });
     }
-    const payload = decoded as JwtPayload;
-    console.log(decoded);
-    client = payload.authRequestClientKey;
-  });
+  }
+
+  let client: string | undefined = undefined;
+  if (typeof decoded !== 'undefined' && typeof decoded !== 'string') {
+    client = decoded.authRequestClientKey;
+  }
   if (typeof client === 'undefined') {
     return res.status(401).json({
       error: 'REFRESH_TOKEN_INVALID',
@@ -74,17 +60,20 @@ export const refreshAuth: RequestHandler = (req, res) => {
     });
   }
 
-  const payload: JwtPayload = { authRequestClientKey: client };
-  // TODO this was allowing me to pass a string here too. wtf
+  createAndSetAuthCookies(res, client);
+};
+
+const createAndSetAuthCookies = (res: Response, client: string) => {
+  const payload: JwtRequestPayload = { authRequestClientKey: client };
   const newAccessToken = generateAccessToken(payload);
-  res.cookie('access_token', newAccessToken, {
+  res.cookie(accessTokenName, newAccessToken, {
     httpOnly: true,
     secure: true,
     sameSite: 'none',
     maxAge: accessAgeS * 1000,
   });
   const newRefreshToken = generateRefreshToken(payload);
-  res.cookie('refresh_token', newRefreshToken, {
+  res.cookie(refreshTokenName, newRefreshToken, {
     httpOnly: true,
     secure: true,
     sameSite: 'none',

--- a/src/features/auth/auth.controllers.ts
+++ b/src/features/auth/auth.controllers.ts
@@ -36,6 +36,7 @@ export const grantAuth: RequestHandler = (req, res) => {
   }
 
   createAndSetAuthCookies(res, client);
+  res.status(200).json({ message: 'Auth granted' });
 };
 
 export const refreshAuth: RequestHandler = (req, res) => {
@@ -69,6 +70,7 @@ export const refreshAuth: RequestHandler = (req, res) => {
   }
 
   createAndSetAuthCookies(res, client);
+  res.status(200).json({ message: 'Auth refreshed' });
 };
 
 const createAndSetAuthCookies = (res: Response, client: string) => {
@@ -87,5 +89,4 @@ const createAndSetAuthCookies = (res: Response, client: string) => {
     sameSite: 'none',
     maxAge: refreshAgeS * 1000,
   });
-  res.status(200).json({ message: 'Auth refreshed' });
 };

--- a/src/features/auth/auth.controllers.ts
+++ b/src/features/auth/auth.controllers.ts
@@ -1,7 +1,15 @@
 import type { RequestHandler } from 'express';
+import jwt from 'jsonwebtoken';
 
 import { config } from '../../shared/config.js';
-import { generateToken, maxAgeS } from './auth.service.js';
+import { readRefreshToken } from '../../shared/middleware/auth.js';
+import {
+  accessAgeS,
+  generateAccessToken,
+  generateRefreshToken,
+  type JwtPayload,
+  refreshAgeS,
+} from './auth.service.js';
 
 const authRequestHeader = 'internal-auth-key';
 const authRequestClientKey = 'auth-request-client';
@@ -17,12 +25,70 @@ export const grantAuth: RequestHandler = (req, res) => {
     return res.status(400).json({ message: 'Bad Request, no client provided' });
   }
 
-  const token = generateToken({ authRequestClientKey: client });
-  res.cookie('access_token', token, {
+  const payload: JwtPayload = { authRequestClientKey: client };
+  // TODO this was allowing me to pass a string. wtf
+  const accessToken = generateAccessToken(payload);
+  res.cookie('access_token', accessToken, {
     httpOnly: true,
     secure: true,
     sameSite: 'none',
-    maxAge: maxAgeS * 1000,
+    maxAge: accessAgeS * 1000,
+  });
+
+  const refreshToken = generateRefreshToken(payload);
+  res.cookie('refresh_token', refreshToken, {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'none',
+    maxAge: refreshAgeS * 1000,
   });
   res.status(200).json({ message: 'Auth granted' });
+};
+
+export const refreshAuth: RequestHandler = (req, res) => {
+  let client;
+  console.log(req);
+  const refreshToken = readRefreshToken(req);
+  console.log(refreshToken);
+  jwt.verify(refreshToken, config.jwtKey, (err: unknown, decoded: unknown) => {
+    if (err instanceof Error && err.name === 'TokenExpiredError') {
+      console.log('REFRESH_TOKEN_EXPIRED');
+      return res
+        .status(401)
+        .json({ error: 'REFRESH_TOKEN_EXPIRED', message: 'Session expired' });
+    } else if (err) {
+      console.log('REFRESH_TOKEN_INVALID');
+      return res.status(401).json({
+        error: 'REFRESH_TOKEN_INVALID',
+        message: 'Invalid refresh token',
+      });
+    }
+    const payload = decoded as JwtPayload;
+    console.log(decoded);
+    client = payload.authRequestClientKey;
+  });
+  if (typeof client === 'undefined') {
+    return res.status(401).json({
+      error: 'REFRESH_TOKEN_INVALID',
+      message: 'Refresh token provided no client',
+    });
+  }
+
+  const payload: JwtPayload = { authRequestClientKey: client };
+  // TODO this was allowing me to pass a string here too. wtf
+  const newAccessToken = generateAccessToken(payload);
+  res.cookie('access_token', newAccessToken, {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'none',
+    maxAge: accessAgeS * 1000,
+  });
+  const newRefreshToken = generateRefreshToken(payload);
+  res.cookie('refresh_token', newRefreshToken, {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'none',
+    maxAge: refreshAgeS * 1000,
+  });
+  res.status(200).json({ message: 'Auth refreshed' });
 };

--- a/src/features/auth/auth.routes.ts
+++ b/src/features/auth/auth.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 
-import { grantAuth } from './auth.controllers.js';
+import { grantAuth, refreshAuth } from './auth.controllers.js';
 
 export const authRoutes = Router();
 authRoutes.post('/grant', grantAuth);
+authRoutes.post('/refresh', refreshAuth);

--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -16,7 +16,5 @@ export const generateAccessToken = (payload: JwtRequestPayload) =>
 export const generateRefreshToken = (payload: JwtRequestPayload) =>
   generateToken(payload, refreshAgeS);
 
-// TODO: forcing this to always expire for testing
-export const accessAgeS = 1;
-// export const accessAgeS = 15 * 60; // 15 minutes
+export const accessAgeS = 15 * 60; // 15 minutes
 export const refreshAgeS = 60 * 60 * 24 * 7; // 7 days

--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -2,8 +2,23 @@ import jwt from 'jsonwebtoken';
 
 import { config } from '../../shared/config.js';
 
-export const maxAgeS = 15 * 60; // 15 minutes
+export interface JwtPayload {
+  authRequestClientKey: string;
+}
 
-export const generateToken = (payload: object) => {
-  return jwt.sign(payload, config.jwtKey, { expiresIn: maxAgeS });
+const generateToken = (payload: JwtPayload, expiresIn: number) => {
+  console.log(payload);
+  console.log(expiresIn);
+  return jwt.sign(payload, config.jwtKey, { expiresIn });
 };
+
+export const generateAccessToken = (payload: JwtPayload) =>
+  generateToken(payload, accessAgeS);
+
+export const generateRefreshToken = (payload: JwtPayload) =>
+  generateToken(payload, refreshAgeS);
+
+// TODO: forcing this to always expire for testing
+export const accessAgeS = 1;
+// export const accessAgeS = 15 * 60; // 15 minutes
+export const refreshAgeS = 60 * 60 * 24 * 7; // 7 days

--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -2,20 +2,18 @@ import jwt from 'jsonwebtoken';
 
 import { config } from '../../shared/config.js';
 
-export interface JwtPayload {
+export interface JwtRequestPayload {
   authRequestClientKey: string;
 }
 
-const generateToken = (payload: JwtPayload, expiresIn: number) => {
-  console.log(payload);
-  console.log(expiresIn);
+const generateToken = (payload: JwtRequestPayload, expiresIn: number) => {
   return jwt.sign(payload, config.jwtKey, { expiresIn });
 };
 
-export const generateAccessToken = (payload: JwtPayload) =>
+export const generateAccessToken = (payload: JwtRequestPayload) =>
   generateToken(payload, accessAgeS);
 
-export const generateRefreshToken = (payload: JwtPayload) =>
+export const generateRefreshToken = (payload: JwtRequestPayload) =>
   generateToken(payload, refreshAgeS);
 
 // TODO: forcing this to always expire for testing

--- a/src/shared/middleware/auth.ts
+++ b/src/shared/middleware/auth.ts
@@ -3,16 +3,29 @@ import type { Request, RequestHandler } from 'express';
 import jwt from 'jsonwebtoken';
 
 import { config } from '../config.js';
+
 export const requireAuth: RequestHandler = (req, res, next) => {
-  const accessToken = getAccessToken(req);
+  const accessToken = readAccessToken(req);
   if (!accessToken) {
-    res.status(401).json({ message: 'Unauthorized, no token provided' });
+    res.status(401).json({
+      name: errorTokenNotProvided,
+      message: 'Unauthorized, no token provided',
+    });
     return;
   }
 
   jwt.verify(accessToken, config.jwtKey, (err: unknown) => {
-    if (err) {
-      res.status(401).json({ message: 'Unauthorized, invalid token' });
+    if (err instanceof Error && err.name === 'TokenExpiredError') {
+      // TODO need to type these error responses, probably within api-types
+      res.status(401).json({
+        name: errorAuthTokenExpired,
+        message: 'Auth token expired, please refresh',
+      });
+    } else if (err) {
+      res.status(401).json({
+        name: errorAuthTokenInvalid,
+        message: 'Unauthorized, invalid token',
+      });
       return;
     }
   });
@@ -20,8 +33,21 @@ export const requireAuth: RequestHandler = (req, res, next) => {
   next();
 };
 
-const getAccessToken = (req: Request) => {
+const readAccessToken = (req: Request) => {
   return (
     req.cookies?.access_token || parse(req.headers.cookie || '').access_token
   );
 };
+
+export const readRefreshToken = (req: Request) => {
+  return (
+    req.cookies?.refresh_token || parse(req.headers.cookie || '').refresh_token
+  );
+};
+
+// TODO need to standardize these around app
+const errorTokenNotProvided = 'TOKEN_NOT_PROVIDED';
+const errorAuthTokenExpired = 'AUTH_TOKEN_EXPIRED';
+const errorAuthTokenInvalid = 'AUTH_TOKEN_INVALID';
+export const errorRefreshTokenExpired = 'REFRESH_TOKEN_EXPIRED';
+export const errorRefreshTokenInvalid = 'REFRESH_TOKEN_INVALID';

--- a/src/shared/middleware/auth.ts
+++ b/src/shared/middleware/auth.ts
@@ -1,3 +1,4 @@
+import { authErrors } from '@seanboose/personal-website-api-types';
 import { parse } from 'cookie';
 import type { Request, RequestHandler } from 'express';
 import jwt from 'jsonwebtoken';
@@ -8,7 +9,7 @@ export const requireAuth: RequestHandler = (req, res, next) => {
   const accessToken = readAccessToken(req);
   if (!accessToken) {
     res.status(401).json({
-      name: errorTokenNotProvided,
+      name: authErrors.accessTokenNotProvided,
       message: 'Unauthorized, no token provided',
     });
     return;
@@ -16,14 +17,13 @@ export const requireAuth: RequestHandler = (req, res, next) => {
 
   jwt.verify(accessToken, config.jwtKey, (err: unknown) => {
     if (err instanceof Error && err.name === 'TokenExpiredError') {
-      // TODO need to type these error responses, probably within api-types
       res.status(401).json({
-        name: errorAuthTokenExpired,
+        name: authErrors.accessTokenExpired,
         message: 'Auth token expired, please refresh',
       });
     } else if (err) {
       res.status(401).json({
-        name: errorAuthTokenInvalid,
+        name: authErrors.accessTokenInvalid,
         message: 'Unauthorized, invalid token',
       });
       return;
@@ -44,10 +44,3 @@ export const readRefreshToken = (req: Request) => {
     req.cookies?.refresh_token || parse(req.headers.cookie || '').refresh_token
   );
 };
-
-// TODO need to standardize these around app
-const errorTokenNotProvided = 'TOKEN_NOT_PROVIDED';
-const errorAuthTokenExpired = 'AUTH_TOKEN_EXPIRED';
-const errorAuthTokenInvalid = 'AUTH_TOKEN_INVALID';
-export const errorRefreshTokenExpired = 'REFRESH_TOKEN_EXPIRED';
-export const errorRefreshTokenInvalid = 'REFRESH_TOKEN_INVALID';

--- a/src/shared/middleware/auth.ts
+++ b/src/shared/middleware/auth.ts
@@ -1,4 +1,8 @@
-import { authErrors } from '@seanboose/personal-website-api-types';
+import {
+  authAccessTokenName,
+  authErrors,
+  authRefreshTokenName,
+} from '@seanboose/personal-website-api-types';
 import { parse } from 'cookie';
 import type { Request, RequestHandler } from 'express';
 import jwt from 'jsonwebtoken';
@@ -19,12 +23,12 @@ export const requireAuth: RequestHandler = (req, res, next) => {
     if (err instanceof Error && err.name === 'TokenExpiredError') {
       res.status(401).json({
         name: authErrors.accessTokenExpired,
-        message: 'Auth token expired, please refresh',
+        message: 'Access token expired, please refresh auth',
       });
     } else if (err) {
       res.status(401).json({
         name: authErrors.accessTokenInvalid,
-        message: 'Unauthorized, invalid token',
+        message: 'Unauthorized, invalid access token',
       });
       return;
     }
@@ -33,14 +37,16 @@ export const requireAuth: RequestHandler = (req, res, next) => {
   next();
 };
 
-const readAccessToken = (req: Request) => {
-  return (
-    req.cookies?.access_token || parse(req.headers.cookie || '').access_token
-  );
+export const readAccessToken = (req: Request) => {
+  return readCookieWithHeaderFallback(req, authAccessTokenName);
 };
 
 export const readRefreshToken = (req: Request) => {
+  return readCookieWithHeaderFallback(req, authRefreshTokenName);
+};
+
+const readCookieWithHeaderFallback = (req: Request, cookieName: string) => {
   return (
-    req.cookies?.refresh_token || parse(req.headers.cookie || '').refresh_token
+    req.cookies?.[cookieName] || parse(req.headers.cookie || '')[cookieName]
   );
 };


### PR DESCRIPTION
add a refresh_token with longer expiration time than access_token to JWT auth flow. this allows the client to "sign in" with a secret value once at the start of a session to get a short-lived access_token, and then refresh that access_token with a longer-lived refresh_token that doesn't require sending secrets.

this provides the following benefits:
- allows for longer sessions without compromising security (compromised access_tokens expire quickly)
- when we have an actual login flow, users won't have to go through it nearly as often
- the refresh_token lives longer but is only shared when refreshing, reducing exposure
- eventually we can store refresh tokens in a database and control access for specific users
