### PR TITLE
start using more robust types from api-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "description": "",
   "main": "dist/index.js",
   "scripts": {
-    "dev": "concurrently -c yellow,cyan \"npm:dev:tsx\" \"npm:lint:watch\"",
+    "dev": "concurrently -c yellow,cyan,magenta \"npm:dev:tsx\" \"npm:dev:lint\" \"npm:dev:typecheck\"",
+    "dev:lint": "nodemon --watch src --ext js,ts,jsx,tsx --delay 100ms --exec \"npm run lint\"",
     "dev:tsx": "tsx watch src/index.ts",
+    "dev:typecheck": "tsc --noEmit --watch",
     "build": "npm run lint && npm run build:ts",
     "build:ts": "tsc",
     "serve": "node dist/index.js",
     "lint": "eslint src",
-    "lint:watch": "nodemon --watch src --ext js,ts,jsx,tsx --delay 100ms --exec \"npm run lint\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -21,13 +22,14 @@
     "cookie": "^1.0.2",
     "cors": "^2.8.5",
     "express": "^5.1.0",
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.876.0",
     "@aws-sdk/s3-request-presigner": "^3.876.0",
     "@eslint/js": "^9.34.0",
-    "@seanboose/personal-website-api-types": "1.0.11",
+    "@seanboose/personal-website-api-types": "1.0.12",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/jsonwebtoken": "^9.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
+      zod:
+        specifier: ^4.1.12
+        version: 4.1.12
     devDependencies:
       '@aws-sdk/client-s3':
         specifier: ^3.876.0
@@ -31,8 +34,8 @@ importers:
         specifier: ^9.34.0
         version: 9.38.0
       '@seanboose/personal-website-api-types':
-        specifier: 1.0.11
-        version: 1.0.11
+        specifier: 1.0.12
+        version: 1.0.12
       '@types/cors':
         specifier: ^2.8.19
         version: 2.8.19
@@ -467,8 +470,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@seanboose/personal-website-api-types@1.0.11':
-    resolution: {integrity: sha512-tjd6MBB79I4iM10P2uP/dzu0Jw4Pfds7qNBqmjjiXa99goOs9dvcJu8rBRUrf5IBW0WoUazLjcKiIfLtd+4TVw==, tarball: https://npm.pkg.github.com/download/@seanboose/personal-website-api-types/1.0.11/6016af5154961cd8f8119a1e908f4f09812ae479}
+  '@seanboose/personal-website-api-types@1.0.12':
+    resolution: {integrity: sha512-NDZ3AZ9ipIIuiO3c7O3278J09CKkGPa7C5JgJdIxWBAGm7O5qudNvLIDpyQcfQA3wlwBLI2x+5CH7xmS/4Nvnw==, tarball: https://npm.pkg.github.com/download/@seanboose/personal-website-api-types/1.0.12/476785d1531c8edb6d285d496915a14a66b253fe}
 
   '@smithy/abort-controller@4.2.3':
     resolution: {integrity: sha512-xWL9Mf8b7tIFuAlpjKtRPnHrR8XVrwTj5NPYO/QwZPtc0SDLsPxb56V5tzi5yspSMytISHybifez+4jlrx0vkQ==}
@@ -1664,6 +1667,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@4.1.12:
+    resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
+
 snapshots:
 
   '@aws-crypto/crc32@5.2.0':
@@ -2299,7 +2305,9 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@seanboose/personal-website-api-types@1.0.11': {}
+  '@seanboose/personal-website-api-types@1.0.12':
+    dependencies:
+      zod: 4.1.12
 
   '@smithy/abort-controller@4.2.3':
     dependencies:
@@ -3700,3 +3708,5 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zod@4.1.12: {}

--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -6,10 +6,6 @@ export interface JwtRequestPayload {
   authRequestClientKey: string;
 }
 
-const generateToken = (payload: JwtRequestPayload, expiresIn: number) => {
-  return jwt.sign(payload, config.jwtKey, { expiresIn });
-};
-
 export const createAuthTokens = (client: string) => {
   const payload: JwtRequestPayload = { authRequestClientKey: client };
   const accessTokenExpiresIn = config.authAccessTokenExpiresIn;
@@ -20,4 +16,8 @@ export const createAuthTokens = (client: string) => {
     refreshToken: generateToken(payload, refreshTokenExpiresIn),
     refreshExpiresIn: refreshTokenExpiresIn,
   };
+};
+
+const generateToken = (payload: JwtRequestPayload, expiresIn: number) => {
+  return jwt.sign(payload, config.jwtKey, { expiresIn });
 };

--- a/src/features/images/images.controllers.ts
+++ b/src/features/images/images.controllers.ts
@@ -1,8 +1,14 @@
+import { type ImagesListResponse } from '@seanboose/personal-website-api-types';
 import type { RequestHandler } from 'express';
 
 import { getImageList } from './images.service.js';
 
-export const listImages: RequestHandler = async (req, res, next) => {
+export const listImages: RequestHandler<
+  never,
+  ImagesListResponse,
+  never,
+  never
+> = async (req, res, next) => {
   try {
     const result = await getImageList();
     return res.status(200).json({ images: result });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import express from 'express';
 import { authRoutes } from './features/auth/auth.routes.js';
 import { imagesRoutes } from './features/images/images.routes.js';
 import { config, envDevelopment } from './shared/config.js';
+import { handleApiErrors } from './shared/middleware/auth.js';
 
 const app = express();
 
@@ -26,6 +27,8 @@ app.use('/api/auth', authRoutes);
 app.get('/api/hello', (req, res) => {
   res.json({ message: 'Hello from backend!' });
 });
+
+app.use(handleApiErrors);
 
 const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
- use types for and validate endpoint request bodies and headers
- use types for endpoint responses
- add typechecking to dev scripts
- add handleApiErrors middleware to massage errors into ApiErrors for client to consume