### PR TITLE
move api-types from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
+    "@seanboose/personal-website-api-types": "1.0.12",
     "cookie": "^1.0.2",
     "cors": "^2.8.5",
     "express": "^5.1.0",
@@ -29,7 +30,6 @@
     "@aws-sdk/client-s3": "^3.876.0",
     "@aws-sdk/s3-request-presigner": "^3.876.0",
     "@eslint/js": "^9.34.0",
-    "@seanboose/personal-website-api-types": "1.0.12",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/jsonwebtoken": "^9.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@seanboose/personal-website-api-types':
+        specifier: 1.0.12
+        version: 1.0.12
       cookie:
         specifier: ^1.0.2
         version: 1.0.2
@@ -33,9 +36,6 @@ importers:
       '@eslint/js':
         specifier: ^9.34.0
         version: 9.38.0
-      '@seanboose/personal-website-api-types':
-        specifier: 1.0.12
-        version: 1.0.12
       '@types/cors':
         specifier: ^2.8.19
         version: 2.8.19


### PR DESCRIPTION
adding zod schema validation made it so that the @seanboose/personal-website-api-types package is used during runtime, so it's no longer a devDependency.