### PR TITLE
fix path for listImages query

### DIFF
--- a/src/features/images/images.service.ts
+++ b/src/features/images/images.service.ts
@@ -13,12 +13,15 @@ export const getImageList = async () => {
 
   const command = new ListObjectsV2Command({
     Bucket: config.s3ImagesBucket,
+    Prefix: 'auth-image',
   });
   const response = await s3.send(command);
   if (response.Contents) {
     const fileNames = response.Contents.map((item) => {
       return item.Key;
-    }).filter((key) => key !== undefined);
+    })
+      .filter((key) => key !== undefined)
+      .filter((key) => key.endsWith('.png'));
     const imageUrls = await getImageUrls(fileNames);
     images = fileNames.map((fileName) => ({
       fileName,


### PR DESCRIPTION
i messed with some of the s3 bucket contents, which effectively broke my listImages endpoint (it was just returning all files at the root of the bucket). i moved that image into its own auth-images folder and now return pngs only from it